### PR TITLE
fix: arbitrary formatting change to trigger release

### DIFF
--- a/errorutils/errors.go
+++ b/errorutils/errors.go
@@ -29,7 +29,7 @@ func LogOnErr(logEntry *logrus.Entry, message string, err error) {
 	}
 }
 
-//PanicWithTrace will log a formatted stack trace at the panic level, which will capture the error if sentry is enabled
+// PanicWithTrace will log a formatted stack trace at the panic level, which will capture the error if sentry is enabled
 func PanicOnErr(logEntry *logrus.Entry, message string, err error) {
 	LogOnErr(logEntry, message, err)
 	if err != nil {


### PR DESCRIPTION
I'm working with a project that is importing this package, and it's failing to compile because:
```
go: github.com/catalystcommunity/app-utils-go@v1.0.8: parsing go.mod:
        module declares its path as: github.com/catalystsquad/app-utils-go
                but was required as: github.com/catalystcommunity/app-utils-go
```

this seems to be that the packaged version of v1.0.8 still contains the old go.mod file that references catalystsquad.

the change here is just a simple formatting change that was caused when i ran
```
go fmt ./...
```

the `fix` commit type should hopefully release a new version and the package should be importable again. hoping that all the release stuff all works still